### PR TITLE
Add a simple JSON backed store for situations when you can't use SSM

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"strings"
 
+	"chamber/store"
+
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +32,7 @@ func delete(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate key")
 	}
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := store.NewStore(numRetries)
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"strings"
 
+	"chamber/store"
+
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +28,7 @@ var execCmd = &cobra.Command{
 		}
 		return nil
 	},
-	RunE:  execRun,
+	RunE: execRun,
 }
 
 func init() {
@@ -39,7 +40,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	services, command, commandArgs := args[:dashIx], args[dashIx], args[dashIx+1:]
 
 	env := environ(os.Environ())
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := store.NewStore(numRetries)
 	for _, service := range services {
 		if err := validateService(service); err != nil {
 			return errors.Wrap(err, "Failed to validate service")

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -10,9 +10,10 @@ import (
 	"sort"
 	"strings"
 
+	"chamber/store"
+
 	"github.com/magiconair/properties"
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +39,7 @@ func init() {
 func runExport(cmd *cobra.Command, args []string) error {
 	var err error
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := store.NewStore(numRetries)
 	params := make(map[string]string)
 	for _, service := range args {
 		if err := validateService(service); err != nil {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"chamber/store"
+
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +35,7 @@ func history(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate key")
 	}
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := store.NewStore(numRetries)
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"chamber/store"
+
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +35,7 @@ func list(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := store.NewStore(numRetries)
 	secrets, err := secretStore.List(service, withValues)
 	if err != nil {
 		return errors.Wrap(err, "Failed to list store contents")

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"chamber/store"
+
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"strings"
 
+	"chamber/store"
+
 	"github.com/pkg/errors"
-	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
 
@@ -58,7 +59,7 @@ func write(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	secretStore := store.NewSSMStore(numRetries)
+	secretStore := store.NewStore(numRetries)
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/segmentio/chamber/cmd"
+import "chamber/cmd"
 
 func main() {
 	cmd.Execute()

--- a/store/jsonstore.go
+++ b/store/jsonstore.go
@@ -21,7 +21,10 @@ func NewJSONStore(filePath string) *JSONStore {
 	raw, err := ioutil.ReadFile(filePath)
 
 	if err != nil {
-		panic(err)
+		// No file? No Secrets
+		return &JSONStore{
+			services: make(map[string]service),
+		}
 	}
 
 	var jsonData map[string]interface{}

--- a/store/jsonstore.go
+++ b/store/jsonstore.go
@@ -1,0 +1,99 @@
+package store
+
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
+// ensure JSONStore conforms to Store interface
+var _ Store = &JSONStore{}
+
+type JSONStore struct {
+	services map[string]service
+}
+
+type service struct {
+	secrets map[string]Secret
+}
+
+func NewJSONStore(filePath string) *JSONStore {
+
+	raw, err := ioutil.ReadFile(filePath)
+
+	if err != nil {
+		panic(err)
+	}
+
+	var jsonData map[string]interface{}
+	json.Unmarshal(raw, &jsonData)
+
+	services := make(map[string]service)
+	for k, v := range jsonData {
+		services[k] = extractService(v)
+	}
+
+	return &JSONStore{
+		services: services,
+	}
+}
+
+func (s *JSONStore) Read(id SecretId, version int) (Secret, error) {
+	if service, ok := s.services[id.Service]; ok {
+		if value, ok := service.secrets[id.Key]; ok {
+			return value, nil
+		}
+	}
+
+	return Secret{}, ErrSecretNotFound
+}
+
+func (s *JSONStore) List(service string, includeValues bool) ([]Secret, error) {
+	if service, ok := s.services[service]; ok {
+		secrets := make([]Secret, len(service.secrets))
+		for _, s := range service.secrets {
+			secrets = append(secrets, s)
+		}
+
+		return secrets, nil
+	}
+
+	return []Secret{}, nil
+}
+
+func (s *JSONStore) History(id SecretId) ([]ChangeEvent, error) {
+	// History is not supported by JSON Store
+	return []ChangeEvent{}, nil
+}
+
+func (s *JSONStore) Delete(id SecretId) error {
+	// Delete is not supported by JSON Store
+	return nil
+}
+
+func (s *JSONStore) Write(id SecretId, value string) error {
+	// Write is not supported by JSON Store
+	return nil
+}
+
+func extractService(json interface{}) service {
+	jsonData := json.(map[string]interface{})
+	secrets := make(map[string]Secret)
+
+	for k, v := range jsonData {
+		secrets[k] = extractSecret(k, v)
+	}
+
+	return service{
+		secrets: secrets,
+	}
+}
+
+func extractSecret(key string, json interface{}) Secret {
+	return Secret{
+		Value: json.(*string),
+		Meta: SecretMetadata{
+			Version: 1,
+			Key:     key,
+		},
+	}
+}

--- a/store/jsonstore.go
+++ b/store/jsonstore.go
@@ -49,7 +49,7 @@ func (s *JSONStore) Read(id SecretId, version int) (Secret, error) {
 
 func (s *JSONStore) List(service string, includeValues bool) ([]Secret, error) {
 	if service, ok := s.services[service]; ok {
-		secrets := make([]Secret, len(service.secrets))
+		secrets := make([]Secret, 0, len(service.secrets))
 		for _, s := range service.secrets {
 			secrets = append(secrets, s)
 		}
@@ -89,8 +89,9 @@ func extractService(json interface{}) service {
 }
 
 func extractSecret(key string, json interface{}) Secret {
+	value := json.(string)
 	return Secret{
-		Value: json.(*string),
+		Value: &value,
 		Meta: SecretMetadata{
 			Version: 1,
 			Key:     key,

--- a/store/store.go
+++ b/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"errors"
+	"os"
 	"time"
 )
 
@@ -58,4 +59,13 @@ type Store interface {
 	List(service string, includeValues bool) ([]Secret, error)
 	History(id SecretId) ([]ChangeEvent, error)
 	Delete(id SecretId) error
+}
+
+func NewStore(numRetries int) Store {
+	jsonPath, useJSON := os.LookupEnv("CHAMBER_JSON_PATH")
+	if useJSON {
+		return NewJSONStore(jsonPath)
+	}
+
+	return NewSSMStore(numRetries)
 }


### PR DESCRIPTION
This allows the use of Chamber against non-AWS environments by setting `CHAMBER_JSON_PATH` to a Json file structured like:

```
{
    "service-name-1" : {
         "secret-key" : "secret-value",
         "other-secret-key" : "other-secret-value",
    },
    "service-name-2" : {
         "secret-key" : "secret-value"
    }
}
```

This is so that your application can be designed to always look for secrets in the environment, even if it isn't always ran somewhere where you can access EC2 Parameter store.